### PR TITLE
Update ApnsHttp2Connection.cs

### DIFF
--- a/PushSharp.Apple/ApnsHttp2Connection.cs
+++ b/PushSharp.Apple/ApnsHttp2Connection.cs
@@ -74,7 +74,7 @@ namespace PushSharp.Apple
 
             var payload = notification.Payload.ToString ();
 
-            var data = Encoding.ASCII.GetBytes (payload);
+            var data = Encoding.UTF8.GetBytes (payload);
 
             var headers = new NameValueCollection ();
             headers.Add ("apns-id", notification.Uuid); // UUID


### PR DESCRIPTION
Fix to display special characters properly in received push notification (i.e. "è" or "è")